### PR TITLE
Fixing pushing of tags.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,7 +36,7 @@ task tagRelease {
                 name = "v$version"
                 message = "Release of ${version}"
             }
-            grgit.push()
+            grgit.push(refsOrSpecs: ["v$version"])
         }
         catch (RefAlreadyExistsException ignored) {
             logger.warn("Tag v$version already exists.")


### PR DESCRIPTION
## Context

Currently the GHA will not push release tag to origin.

Fixing pushing of tags.

## Checklist
- [x] Change meets or does not compromise the [Baseline Security Requirements](https://transferwise.atlassian.net/wiki/spaces/EKB/pages/434929973/Baseline+Security+Requirements) 
