### PR TITLE
do not enforce springboot platform

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.2] - 2022-01-31
+
+* do not enforce SpringBoot platform, let the service using us decide
+* upgrade to use latest SpringBoot 2.5.x
+
 ## [0.3.1] - 2021-12-28
 
 ### Changed

--- a/build.common.gradle
+++ b/build.common.gradle
@@ -15,10 +15,10 @@ repositories {
 }
 
 dependencies {
-    annotationProcessor platform("org.springframework.boot:spring-boot-dependencies:${springBootVersion}!!")
-    implementation platform("org.springframework.boot:spring-boot-dependencies:${springBootVersion}!!")
-    compileOnly platform("org.springframework.boot:spring-boot-dependencies:${springBootVersion}!!")
-    testAnnotationProcessor platform("org.springframework.boot:spring-boot-dependencies:${springBootVersion}!!")
+    annotationProcessor platform("org.springframework.boot:spring-boot-dependencies:${springBootVersion}")
+    implementation platform("org.springframework.boot:spring-boot-dependencies:${springBootVersion}")
+    compileOnly platform("org.springframework.boot:spring-boot-dependencies:${springBootVersion}")
+    testAnnotationProcessor platform("org.springframework.boot:spring-boot-dependencies:${springBootVersion}")
 
     annotationProcessor 'org.projectlombok:lombok'
     testAnnotationProcessor 'org.projectlombok:lombok'

--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ idea.project {
 }
 
 ext {
-    springBootVersion = "2.5.8"
+    springBootVersion = "2.5.9"
 }
 
 yamlValidator {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=0.3.1
+version=0.3.2


### PR DESCRIPTION
## Context

We move towards springboot 2.6, this lib was enforcing 2.5, so services would not be able to use 2.6 with this lib. Let the service decide the enforced platform.

## Checklist
- [x] Change meets or does not compromise the [Baseline Security Requirements](https://transferwise.atlassian.net/wiki/spaces/EKB/pages/434929973/Baseline+Security+Requirements) 
