### PR TITLE
[RDP-1245]Only start curator if ZK address is configured

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,16 +5,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.0] - 2022-11-17
+
+- do not create curator beans if `tw-curator.zookeeper-connect-string` configuration is missing: one does not have to 
+explicitly set `tw-curator.disabled: true` anymore, not configuring the zookeeper address leads to the same behaviour
+
 ## [0.3.2] - 2022-01-31
 
-* do not enforce SpringBoot platform, let the service using us decide
-* upgrade to use latest SpringBoot 2.5.x
+- do not enforce SpringBoot platform, let the service using us decide
+- upgrade to use latest SpringBoot 2.5.x
 
 ## [0.3.1] - 2021-12-28
 
 ### Changed
 
-* Moving CI from Circle to Github Actions
+- Moving CI from Circle to Github Actions
 
 ## [0.3.0] - 2021-05-31
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=0.3.2
+version=0.4.0

--- a/tw-curator-starter/src/main/java/com/transferwise/common/curator/TwCuratorAutoConfiguration.java
+++ b/tw-curator-starter/src/main/java/com/transferwise/common/curator/TwCuratorAutoConfiguration.java
@@ -11,12 +11,15 @@ import org.apache.curator.framework.state.ConnectionStateListener;
 import org.apache.curator.retry.RetryNTimes;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Configuration;
 
 @ConditionalOnExpression("'${tw-curator.disabled}' != 'true'")
+@ConditionalOnProperty({"tw-curator.zookeeper-connect-string"})
 @Configuration
 @Slf4j
 public class TwCuratorAutoConfiguration {
@@ -31,10 +34,6 @@ public class TwCuratorAutoConfiguration {
   @Bean(destroyMethod = "close")
   @ConditionalOnMissingBean
   public CuratorFramework twCuratorFramework(ApplicationContext applicationContext, TwCuratorProperties properties, RetryPolicy retryPolicy) {
-    if (StringUtils.trimToNull(properties.getZookeeperConnectString()) == null) {
-      throw new IllegalStateException("'tw-curator.zookeeper-connect-string' parameter is missing.");
-    }
-
     Collection<ConnectionStateListener> listeners = applicationContext.getBeansOfType(ConnectionStateListener.class).values();
 
     CuratorFramework curatorFramework = CuratorFrameworkFactory.builder()

--- a/tw-curator-starter/src/test/java/com/transferwise/common/curator/CuratorConfigurationDisabledIntTest.java
+++ b/tw-curator-starter/src/test/java/com/transferwise/common/curator/CuratorConfigurationDisabledIntTest.java
@@ -10,7 +10,7 @@ import org.springframework.test.context.ActiveProfiles;
 
 @ActiveProfiles(profiles = {"integration"})
 @SpringBootTest(classes = {TestApplication.class}, properties = {"tw-curator.disabled=true"})
-public class CuratorConfigurationDisabledTest {
+public class CuratorConfigurationDisabledIntTest {
 
   @Autowired(required = false)
   private CuratorFramework curatorFramework;

--- a/tw-curator-starter/src/test/java/com/transferwise/common/curator/CuratorConfigurationIntTest.java
+++ b/tw-curator-starter/src/test/java/com/transferwise/common/curator/CuratorConfigurationIntTest.java
@@ -10,7 +10,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
 @BaseTestEnvironment
-public class CuratorConfigurationTest {
+public class CuratorConfigurationIntTest {
 
   @Autowired
   private CuratorFramework curatorFramework;

--- a/tw-curator-starter/src/test/java/com/transferwise/common/curator/CuratorConfigurationPropertyMissingIntTest.java
+++ b/tw-curator-starter/src/test/java/com/transferwise/common/curator/CuratorConfigurationPropertyMissingIntTest.java
@@ -8,7 +8,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
 @SpringBootTest(classes = {TestApplication.class})
-public class CuratorConfigurationPropertyMissingTest {
+public class CuratorConfigurationPropertyMissingIntTest {
 
   @Autowired(required = false)
   private CuratorFramework curatorFramework;

--- a/tw-curator-starter/src/test/java/com/transferwise/common/curator/CuratorConfigurationPropertyMissingTest.java
+++ b/tw-curator-starter/src/test/java/com/transferwise/common/curator/CuratorConfigurationPropertyMissingTest.java
@@ -1,0 +1,21 @@
+package com.transferwise.common.curator;
+
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import org.apache.curator.framework.CuratorFramework;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest(classes = {TestApplication.class})
+public class CuratorConfigurationPropertyMissingTest {
+
+  @Autowired(required = false)
+  private CuratorFramework curatorFramework;
+
+  @Test
+  public void shouldNotAutowire() {
+    assertNull(curatorFramework);
+  }
+
+}

--- a/tw-curator-starter/src/test/resources/application-integration.yml
+++ b/tw-curator-starter/src/test/resources/application-integration.yml
@@ -1,0 +1,2 @@
+tw-curator:
+  zookeeper-connect-string: "${ZOOKEEPER_HOST:127.0.0.1}:${ZOOKEEPER_TCP_2181}"

--- a/tw-curator-starter/src/test/resources/application.yml
+++ b/tw-curator-starter/src/test/resources/application.yml
@@ -1,6 +1,3 @@
 spring:
   application:
     name: tw-curator-starter-test
-
-tw-curator:
-  zookeeper-connect-string: "${ZOOKEEPER_HOST:127.0.0.1}:${ZOOKEEPER_TCP_2181}"


### PR DESCRIPTION
## Context

Curator framewok should no be started if the zookeeper address is not configured.

This new behaviour makes it easier to make its usage optional: one does not have to explicitly set `tw-curator.disabled: true` anymore, not configuring the zookeeper address leads to the same behaviour.

<!-- Why is this PR necessary? If available, include links to a JIRA ticket or other relevant documentation. -->

## Checklist
- [x] Change meets or does not compromise the [Baseline Security Requirements](https://transferwise.atlassian.net/wiki/spaces/EKB/pages/434929973/Baseline+Security+Requirements) 
