### PR TITLE
[APPENG-763] Update matrix tests to run with SB 3.2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,10 +18,10 @@ jobs:
       max-parallel: 100
       matrix:
         spring_boot_version:
+          - 3.2.2
           - 3.1.2
           - 3.0.7
           - 2.7.13
-          - 2.6.15
     services:
       zookeeper:
         image: bitnami/zookeeper:3.5.5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.2] - 2024-02-27
+
+### Changed
+- Added support for Spring Boot 3.2.
+  - Updated dependencies.
+
 ## [0.5.1] - 2023-08-01
 
 ### Added

--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ import org.eclipse.jgit.api.errors.RefAlreadyExistsException
 
 buildscript {
     dependencies {
-        classpath "com.avast.gradle:gradle-docker-compose-plugin:0.16.12"
+        classpath "com.avast.gradle:gradle-docker-compose-plugin:0.17.6"
     }
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=0.5.1
+version=0.5.2


### PR DESCRIPTION
## Context

Wise is now supporting Spring Boot 3.2 so matrix tests need to be updated to run with the new version.

## Checklist
- [x] Change meets or does not compromise the [Baseline Security Requirements](https://transferwise.atlassian.net/wiki/spaces/EKB/pages/434929973/Baseline+Security+Requirements) 
